### PR TITLE
updated OQC Client to catch up with the latest QCaaS

### DIFF
--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -9,11 +9,11 @@
 #include "common/Logger.h"
 #include "common/RestClient.h"
 #include "common/ServerHelper.h"
+#include <iostream>
 #include <map>
 #include <regex>
 #include <sstream>
 #include <thread>
-#include <iostream>
 
 namespace cudaq {
 
@@ -35,8 +35,8 @@ private:
   std::vector<std::string> createNTasks(int n);
 
   /// @brief Gets endpoint of a device
-  std::tuple<std::string,std::string>
-      get_qpu_endpoint(std::string,std::string,std::string);
+  std::tuple<std::string, std::string>
+      get_qpu_endpoint(std::string, std::string, std::string);
 
   /// @brief make a compiler config json string parameterising with number of
   /// shots
@@ -119,9 +119,9 @@ std::string get_from_config(BackendConfig config, const std::string &key,
 }
 
 std::string get_from_config_no_low(BackendConfig config, const std::string &key,
-                            const auto &missing_functor) {
-/// This function does the same with get_from_config, but without lowering
-/// Auth tokens are case sensitive and shouldn't be lowered
+                                   const auto &missing_functor) {
+  /// This function does the same with get_from_config, but without lowering
+  /// Auth tokens are case sensitive and shouldn't be lowered
 
   const auto iter = config.find(key);
   auto item = iter != config.end() ? iter->second : missing_functor();
@@ -141,7 +141,6 @@ void check_machine_allowed(const std::string &machine) {
     throw std::runtime_error(stream.str());
   }
 }
-
 
 } // namespace
 
@@ -163,21 +162,14 @@ void OQCServerHelper::initialize(BackendConfig config) {
     return;
   }
 
-  config["entry_url"] = get_from_config(config, 
-                                        "entry_url", 
-                                        make_env_functor("OQC_URL"));
-  config["target"]    = get_from_config(config, 
-                                        "device", 
-                                        make_env_functor("OQC_DEVICE"));
-  config["auth_token"]= get_from_config_no_low(config, 
-                                               "auth_token", 
-                                        make_env_functor("OQC_AUTH_TOKEN"));
-  auto [device_url,dev_id] = 
-     get_qpu_endpoint(
-         config["entry_url"],
-         config["target"],
-         config["auth_token"]
-     );
+  config["entry_url"] =
+      get_from_config(config, "entry_url", make_env_functor("OQC_URL"));
+  config["target"] =
+      get_from_config(config, "device", make_env_functor("OQC_DEVICE"));
+  config["auth_token"] = get_from_config_no_low(
+      config, "auth_token", make_env_functor("OQC_AUTH_TOKEN"));
+  auto [device_url, dev_id] = get_qpu_endpoint(
+      config["entry_url"], config["target"], config["auth_token"]);
   // Set the necessary configuration variables for the OQC API
 
   config["url"] = device_url;
@@ -188,7 +180,7 @@ void OQCServerHelper::initialize(BackendConfig config) {
   config["qubits"] = Machines.at(machine);
 
   // Construct the API job path
-  config["job_path"] = std::string("/")+dev_id+"/tasks" ; 
+  config["job_path"] = std::string("/") + dev_id + "/tasks";
   parseConfigForCommonParams(config);
 
   // Move the passed config into the member variable backendConfig
@@ -201,9 +193,8 @@ bool OQCServerHelper::keyExists(const std::string &key) const {
 }
 
 std::vector<std::string> OQCServerHelper::createNTasks(int n) {
-/// This function returns the task ids as a vector of string.
-/// The same as "create_task_ids" in QCaaS client, client.py
-
+  /// This function returns the task ids as a vector of string.
+  /// The same as "create_task_ids" in QCaaS client, client.py
 
   RestHeaders headers = OQCServerHelper::getHeaders();
   nlohmann::json job;
@@ -218,28 +209,27 @@ std::vector<std::string> OQCServerHelper::createNTasks(int n) {
   return response;
 }
 
-std::tuple<std::string,std::string>
-      OQCServerHelper::get_qpu_endpoint(std::string server_url,
-                                        std::string qpu_id,
-                                        std::string auth_token){
-    RestHeaders headers;
+std::tuple<std::string, std::string>
+OQCServerHelper::get_qpu_endpoint(std::string server_url, std::string qpu_id,
+                                  std::string auth_token) {
+  RestHeaders headers;
 
-    headers["Authentication-Token"] = auth_token;
-    auto response = client.get(server_url, "/admin/qpu",headers,true);
+  headers["Authentication-Token"] = auth_token;
+  auto response = client.get(server_url, "/admin/qpu", headers, true);
 
-    for (auto item: response["items"]){
-       if(item["id"] == qpu_id){
-          std::string device_url = item["url"];
-          size_t pos = device_url.find('/', 8); //Start fter "https://"
-          std::string qpu_server_url = device_url.substr(0, pos);
-          std::string qpu_device_id  = device_url.substr(pos+1);
-          return std::make_tuple(qpu_server_url,qpu_device_id);
-       }
+  for (auto item : response["items"]) {
+    if (item["id"] == qpu_id) {
+      std::string device_url = item["url"];
+      size_t pos = device_url.find('/', 8); // Start fter "https://"
+      std::string qpu_server_url = device_url.substr(0, pos);
+      std::string qpu_device_id = device_url.substr(pos + 1);
+      return std::make_tuple(qpu_server_url, qpu_device_id);
     }
+  }
 
-    std::stringstream stream;
-    stream << "No device:"+qpu_id+" is on "+server_url+"." << std::endl;
-    throw std::runtime_error(stream.str());
+  std::stringstream stream;
+  stream << "No device:" + qpu_id + " is on " + server_url + "." << std::endl;
+  throw std::runtime_error(stream.str());
 }
 
 std::string OQCServerHelper::makeConfig(int shots) {
@@ -247,15 +237,18 @@ std::string OQCServerHelper::makeConfig(int shots) {
          "\"$data\": {\"repeats\": " +
          std::to_string(shots) +
          ", \"repetition_period\": null, \"results_format\": {\"$type\": "
-         "\"<class 'qat.purr.compiler.config.QuantumResultsFormat'>\", \"$data\": "
+         "\"<class 'qat.purr.compiler.config.QuantumResultsFormat'>\", "
+         "\"$data\": "
          "{\"format\": {\"$type\": \"<enum "
-         "'qat.purr.compiler.config.InlineResultsProcessing'>\", \"$value\": 1}, "
+         "'qat.purr.compiler.config.InlineResultsProcessing'>\", \"$value\": "
+         "1}, "
          "\"transforms\": {\"$type\": \"<enum "
          "'qat.purr.compiler.config.ResultsFormatting'>\", \"$value\": 3}}}, "
          "\"metrics\": {\"$type\": \"<enum "
          "'qat.purr.compiler.config.MetricsType'>\", \"$value\": 6}, "
          "\"active_calibrations\": [], \"optimizations\": {\"$type\": \"<class "
-         "'qat.purr.compiler.config.Tket'>\", \"$data\": {\"tket_optimizations\": "
+         "'qat.purr.compiler.config.Tket'>\", \"$data\": "
+         "{\"tket_optimizations\": "
          "{\"$type\": \"<enum 'qat.purr.compiler.config.TketOptimizations'>\", "
          "\"$value\": 30}}}}}";
 }
@@ -286,7 +279,7 @@ OQCServerHelper::createJob(std::vector<KernelExecution> &circuitCodes) {
 
   // Return a tuple containing the job path, headers, and the job message
   return std::make_tuple(backendConfig.at("url") +
-                         backendConfig.at("job_path") + "/submit",
+                             backendConfig.at("job_path") + "/submit",
                          getHeaders(), jobs);
 }
 

--- a/unittests/backends/oqc/OQCTester.cpp
+++ b/unittests/backends/oqc/OQCTester.cpp
@@ -14,8 +14,10 @@
 
 std::string mockPort = "62442";
 std::string auth_token = "fake_auth_token";
+std::string device_id = "qpu:uk:-1:1234567890";
+std::string entry_url = "http://localhost:"+mockPort;
 std::string backendStringTemplate =
-    "oqc;emulate;false;url;http://localhost:{};auth_token;{};device;toshiko;";
+    "oqc;emulate;false;url;http://localhost:{};auth_token;{};device;{};";
 
 bool isValidExpVal(double value) {
   // give us some wiggle room while keep the tests fast
@@ -24,7 +26,7 @@ bool isValidExpVal(double value) {
 
 CUDAQ_TEST(OQCTester, checkSampleSync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token);
+                                   mockPort, auth_token,device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -41,7 +43,7 @@ CUDAQ_TEST(OQCTester, checkSampleSync) {
 
 CUDAQ_TEST(OQCTester, checkSampleAsync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token);
+                                   mockPort, auth_token,device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -58,7 +60,7 @@ CUDAQ_TEST(OQCTester, checkSampleAsync) {
 
 CUDAQ_TEST(OQCTester, checkSampleAsyncLoadFromFile) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token);
+                                   mockPort, auth_token,device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -91,7 +93,7 @@ CUDAQ_TEST(OQCTester, checkSampleAsyncLoadFromFile) {
 
 CUDAQ_TEST(OQCTester, checkObserveSync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token);
+                                   mockPort, auth_token,device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -114,7 +116,7 @@ CUDAQ_TEST(OQCTester, checkObserveSync) {
 
 CUDAQ_TEST(OQCTester, checkObserveAsync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token);
+                                   mockPort, auth_token,device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -139,7 +141,7 @@ CUDAQ_TEST(OQCTester, checkObserveAsync) {
 
 CUDAQ_TEST(OQCTester, checkObserveAsyncLoadFromFile) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token);
+                                   mockPort, auth_token,device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -176,7 +178,9 @@ CUDAQ_TEST(OQCTester, checkObserveAsyncLoadFromFile) {
 }
 
 int main(int argc, char **argv) {
-  setenv("OQC_PASSWORD", auth_token.c_str(), 0);
+  setenv("OQC_URL", entry_url.c_str(), 0);
+  setenv("OQC_AUTH_TOKEN", auth_token.c_str(), 0);
+  setenv("OQC_DEVICE", device_id.c_str(), 0);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/unittests/backends/oqc/OQCTester.cpp
+++ b/unittests/backends/oqc/OQCTester.cpp
@@ -15,7 +15,7 @@
 std::string mockPort = "62442";
 std::string auth_token = "fake_auth_token";
 std::string device_id = "qpu:uk:-1:1234567890";
-std::string entry_url = "http://localhost:"+mockPort;
+std::string entry_url = "http://localhost:" + mockPort;
 std::string backendStringTemplate =
     "oqc;emulate;false;url;http://localhost:{};auth_token;{};device;{};";
 
@@ -26,7 +26,7 @@ bool isValidExpVal(double value) {
 
 CUDAQ_TEST(OQCTester, checkSampleSync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token,device_id);
+                                   mockPort, auth_token, device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -43,7 +43,7 @@ CUDAQ_TEST(OQCTester, checkSampleSync) {
 
 CUDAQ_TEST(OQCTester, checkSampleAsync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token,device_id);
+                                   mockPort, auth_token, device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -60,7 +60,7 @@ CUDAQ_TEST(OQCTester, checkSampleAsync) {
 
 CUDAQ_TEST(OQCTester, checkSampleAsyncLoadFromFile) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token,device_id);
+                                   mockPort, auth_token, device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -93,7 +93,7 @@ CUDAQ_TEST(OQCTester, checkSampleAsyncLoadFromFile) {
 
 CUDAQ_TEST(OQCTester, checkObserveSync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token,device_id);
+                                   mockPort, auth_token, device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -116,7 +116,7 @@ CUDAQ_TEST(OQCTester, checkObserveSync) {
 
 CUDAQ_TEST(OQCTester, checkObserveAsync) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token,device_id);
+                                   mockPort, auth_token, device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);
@@ -141,7 +141,7 @@ CUDAQ_TEST(OQCTester, checkObserveAsync) {
 
 CUDAQ_TEST(OQCTester, checkObserveAsyncLoadFromFile) {
   auto backendString = fmt::format(fmt::runtime(backendStringTemplate),
-                                   mockPort, auth_token,device_id);
+                                   mockPort, auth_token, device_id);
 
   auto &platform = cudaq::get_platform();
   platform.setTargetBackend(backendString);

--- a/utils/mock_qpu/oqc/__init__.py
+++ b/utils/mock_qpu/oqc/__init__.py
@@ -151,7 +151,6 @@ async def reserveJobId(request: TaskIdRequest):
     return [uuid.uuid4() for _ in range(n)]
 
 
-# returns qpu list
 @app.get("/admin/qpu")
 async def qetQpu(authentication_token: str = Header(...)):
 

--- a/utils/mock_qpu/oqc/__init__.py
+++ b/utils/mock_qpu/oqc/__init__.py
@@ -79,15 +79,13 @@ def getNumRequiredQubits(function):
 # Must have a Access Token, Job Program must be Adaptive Profile
 # with entry_point tag
 @app.post("/{deviceId}/tasks/submit")
-async def postJob(
-    data: Dict[str,Any],
-    authentication_token: str = Header(...),
-    content_type: str = Header(...)
-):
+async def postJob(data: Dict[str, Any],
+                  authentication_token: str = Header(...),
+                  content_type: str = Header(...)):
     global createdJobs, shots
     if authentication_token != "fake_auth_token":
         raise HTTPException(status_code=403, detail="Permission denied")
-    tasks = TaskBody(tasks= data["tasks"] )
+    tasks = TaskBody(tasks=data["tasks"])
     for task in tasks.tasks:
         newId = task.task_id
         program = task.program
@@ -146,10 +144,12 @@ async def getJob(jobId: str):
 async def getJob(n=1):
     return [uuid.uuid4() for _ in range(n)]
 
+
 @app.post("/{deviceId}/tasks")
 async def reserveJobId(request: TaskIdRequest):
     n = request.task_count
     return [uuid.uuid4() for _ in range(n)]
+
 
 # returns qpu list
 @app.get("/admin/qpu")
@@ -159,33 +159,31 @@ async def qetQpu(authentication_token: str = Header(...)):
         raise HTTPException(status_code=403, detail="Permission denied")
 
     data = {
-        "items": [
-            {
-                "active": True,
-                "created_at": "2024-04-09T14:24:50.918020+00:00",
-                "created_by": "11111111-1111-1111-1111-111111111111",
-                "feature_set": {
-                    "always_on": True,
-                    "qubit_count": 8,
-                    "simulator": True
-                },
-                "generation": -1,
-                "id": "qpu:uk:-1:1234567890",
-                "name": "OQC Mock Server",
-                "region": "uk",
-                "status": "ACTIVE",
-                "updated_at": "2024-07-29T14:54:46.948951+00:00",
-                "updated_by": "11111111-1111-1111-1111-111111111111",
-                "url": "http://localhost:62442/1234567890"
-            }
-        ],
+        "items": [{
+            "active": True,
+            "created_at": "2024-04-09T14:24:50.918020+00:00",
+            "created_by": "11111111-1111-1111-1111-111111111111",
+            "feature_set": {
+                "always_on": True,
+                "qubit_count": 8,
+                "simulator": True
+            },
+            "generation": -1,
+            "id": "qpu:uk:-1:1234567890",
+            "name": "OQC Mock Server",
+            "region": "uk",
+            "status": "ACTIVE",
+            "updated_at": "2024-07-29T14:54:46.948951+00:00",
+            "updated_by": "11111111-1111-1111-1111-111111111111",
+            "url": "http://localhost:62442/1234567890"
+        }],
         "page": 1,
         "per_page": 10,
         "total": 2
     }
 
-
     return JSONResponse(content=data)
+
 
 def startServer(port):
     uvicorn.run(app, port=port, host='0.0.0.0', log_level="info")

--- a/utils/mock_qpu/oqc/__init__.py
+++ b/utils/mock_qpu/oqc/__init__.py
@@ -13,8 +13,11 @@ import cudaq
 import uuid
 import uvicorn
 from fastapi import FastAPI, HTTPException, Header
+from fastapi.responses import JSONResponse
 from llvmlite import binding as llvm
 from pydantic import BaseModel
+import json
+from typing import Any, Dict
 
 # Define the REST Server App
 app = FastAPI()
@@ -34,6 +37,12 @@ class TaskBody(BaseModel):
 class AuthModel(BaseModel):
     email: str
     password: str
+
+
+class TaskIdRequest(BaseModel):
+    qpu_id: str
+    task_count: int
+    tag: str
 
 
 # Keep track of Job Ids to their Names
@@ -69,20 +78,16 @@ def getNumRequiredQubits(function):
 # Here we expose a way to post jobs,
 # Must have a Access Token, Job Program must be Adaptive Profile
 # with entry_point tag
-@app.post("/tasks/submit")
+@app.post("/{deviceId}/tasks/submit")
 async def postJob(
-    tasks: Union[TaskBody, Task],
-    # access_token: Union[str, None] = Header(alias="Authorization",default=None)
+    data: Dict[str,Any],
+    authentication_token: str = Header(...),
+    content_type: str = Header(...)
 ):
     global createdJobs, shots
-    print("task: ", task)
-
-    # if access_token == None:
-    # raise HTTPException(status_code(401), detail="Credentials not provided")
-    if isinstance(tasks, Task):
-        tasks = TaskBody(tasks=[
-            tasks,
-        ])
+    if authentication_token != "fake_auth_token":
+        raise HTTPException(status_code=403, detail="Permission denied")
+    tasks = TaskBody(tasks= data["tasks"] )
     for task in tasks.tasks:
         newId = task.task_id
         program = task.program
@@ -124,7 +129,7 @@ async def postJob(
 
 # Retrieve the job, simulate having to wait by counting to 3
 # until we return the job results
-@app.get("/tasks/{jobId}/all_info")
+@app.get("/{deviceId}/tasks/{jobId}/all_info")
 async def getJob(jobId: str):
     global countJobGetRequests, createdJobs, shots
 
@@ -141,6 +146,46 @@ async def getJob(jobId: str):
 async def getJob(n=1):
     return [uuid.uuid4() for _ in range(n)]
 
+@app.post("/{deviceId}/tasks")
+async def reserveJobId(request: TaskIdRequest):
+    n = request.task_count
+    return [uuid.uuid4() for _ in range(n)]
+
+# returns qpu list
+@app.get("/admin/qpu")
+async def qetQpu(authentication_token: str = Header(...)):
+
+    if authentication_token != "fake_auth_token":
+        raise HTTPException(status_code=403, detail="Permission denied")
+
+    data = {
+        "items": [
+            {
+                "active": True,
+                "created_at": "2024-04-09T14:24:50.918020+00:00",
+                "created_by": "11111111-1111-1111-1111-111111111111",
+                "feature_set": {
+                    "always_on": True,
+                    "qubit_count": 8,
+                    "simulator": True
+                },
+                "generation": -1,
+                "id": "qpu:uk:-1:1234567890",
+                "name": "OQC Mock Server",
+                "region": "uk",
+                "status": "ACTIVE",
+                "updated_at": "2024-07-29T14:54:46.948951+00:00",
+                "updated_by": "11111111-1111-1111-1111-111111111111",
+                "url": "http://localhost:62442/1234567890"
+            }
+        ],
+        "page": 1,
+        "per_page": 10,
+        "total": 2
+    }
+
+
+    return JSONResponse(content=data)
 
 def startServer(port):
     uvicorn.run(app, port=port, host='0.0.0.0', log_level="info")


### PR DESCRIPTION
OQC Client is updated so that one can throw a job from CUDA-Q. Both CPP and Python bindings are working.
Mock server is also updated, and gives 100% PASS.
