### PR TITLE
Toshiko placement fix

### DIFF
--- a/.github/workflows/config/spelling_allowlist.txt
+++ b/.github/workflows/config/spelling_allowlist.txt
@@ -3,6 +3,7 @@ AFQMC
 API
 APIs
 AST
+AUTH
 Aer
 AlmaLinux
 Anyon
@@ -212,6 +213,8 @@ fmt
 frontend
 frontends
 homogenous
+http
+https
 iff
 increment
 incrementing
@@ -248,6 +251,7 @@ nullary
 observables
 optimizer
 optimizers
+oqc
 parallelization
 parallelize
 parallelizing
@@ -261,6 +265,7 @@ preprocessor
 probability
 programmatically
 pybind
+qpu
 quantize
 quantized
 qubit
@@ -311,6 +316,7 @@ toolchains
 toolset
 transmon
 trotterization
+uk
 unary
 uncomputation
 uncompute

--- a/docs/sphinx/targets/python/oqc.py
+++ b/docs/sphinx/targets/python/oqc.py
@@ -1,4 +1,5 @@
 import cudaq
+import os
 
 # You only have to set the target once! No need to redefine it
 # for every execution call on your kernel.
@@ -7,10 +8,14 @@ import cudaq
 
 # To use the OQC target you will need to set the following environment variables
 # OQC_URL
-# OQC_EMAIL
-# OQC_PASSWORD
+# OQC_DEVICE
+# OQC_AUTH_TOKEN
 # To setup an account, contact oqc_qcaas_support@oxfordquantumcircuits.com
+# or visit https://oqc.tech/access/oqc-cloud/
 
+os.environ["OQC_URL"]="https://cloud.oqc.app" # For most users
+os.environ["OQC_DEVICE"]="qpu:uk:2:d865b5a184" # Lucy simulator
+os.environ["OQC_AUTH_TOKEN"]=<your_token_is_available_at_https://cloud.oqc.app>
 cudaq.set_target("oqc")
 
 

--- a/docs/sphinx/targets/python/oqc.py
+++ b/docs/sphinx/targets/python/oqc.py
@@ -1,4 +1,4 @@
-import cudaq,os
+import cudaq, os
 
 # You only have to set the target once! No need to redefine it
 # for every execution call on your kernel.
@@ -12,9 +12,10 @@ import cudaq,os
 # To setup an account, contact oqc_qcaas_support@oxfordquantumcircuits.com
 # or visit https://oqc.tech/access/oqc-cloud/
 
-os.environ["OQC_URL"]="https://cloud.oqc.app" # For most users
-os.environ["OQC_DEVICE"]="qpu:uk:2:d865b5a184" # Lucy simulator
-os.environ["OQC_AUTH_TOKEN"]=<your_token_is_available_at_https://cloud.oqc.app>
+os.environ["OQC_URL"] = "https://cloud.oqc.app"  # For most users
+os.environ["OQC_DEVICE"] = "qpu:uk:2:d865b5a184"  # Lucy simulator
+os.environ[
+    "OQC_AUTH_TOKEN"] = "<your_token_is_available_at_https://cloud.oqc.app>"
 cudaq.set_target("oqc")
 
 

--- a/docs/sphinx/targets/python/oqc.py
+++ b/docs/sphinx/targets/python/oqc.py
@@ -1,5 +1,4 @@
-import cudaq
-import os
+import cudaq,os
 
 # You only have to set the target once! No need to redefine it
 # for every execution call on your kernel.

--- a/docs/sphinx/using/backends/hardware.rst
+++ b/docs/sphinx/using/backends/hardware.rst
@@ -538,39 +538,41 @@ OQC
 .. _oqc-backend:
 
 `Oxford Quantum Circuits <https://oxfordquantumcircuits.com/>`__ (OQC) is currently providing CUDA-Q integration for multiple Quantum Processing Unit types.
-The 8 qubit ring topology Lucy device and the 32 qubit Kagome lattice topology Toshiko device are both supported via machine options described below.
+The 8 qubit ring topology Lucy simulator and the 32 qubit Kagome lattice topology Toshiko device are both supported via machine options described below.
+Note that Toshiko is currently treated as 8-qubit-full-connectivity-machine on CUDA-Q due to the complex connectivity of Toshiko qubits, which requires the serverside compilation.
 
 Setting Credentials
 `````````````````````````
 
 In order to use the OQC devices you will need to register.
-Registration is achieved by contacting `oqc_qcaas_support@oxfordquantumcircuits.com`.
+Registration is achieved by contacting `oqc_qcaas_support@oxfordquantumcircuits.com` or visiting https://oqc.tech/access/oqc-cloud/.
 
-Once registered you will be able to authenticate with your ``email`` and ``password``
+Once registered you will be able to authenticate with your ``auth_token``.
 
 There are three environment variables that the OQC target will look for during configuration:
 
-1. ``OQC_URL``
-2. ``OQC_EMAIL``
-3. ``OQC_PASSWORD`` - is mandatory
+1. ``OQC_URL`` (for most users, https://cloud.oqc.app)
+2. ``OQC_DEVICE`` (Lucy sim. qpu:uk:2:d865b5a184, otherwise check at http://cloud.oqc.app)
+3. ``OQC_AUTH_TOKEN`` (your own token is available on https://cloud.oqc.app)
 
 Submission from C++
 `````````````````````````
 
 To target quantum kernel code for execution on the OQC platform, provide the flag ``--target oqc`` to the ``nvq++`` compiler.
 
-Users may provide their :code:`email` and :code:`url` as extra arguments
-
 .. code:: bash
 
-    nvq++ --target oqc --oqc-email <email> --oqc-url <url> src.cpp -o executable
+    export OQC_URL=<url>
+    export OQC_DEVICE=<device_id>
+    export OQC_AUTH_TOKEN=<your_auth_token>
+    nvq++ --target oqc src.cpp -o executable
 
 Where both environment variables and extra arguments are supplied, precedent is given to the extra arguments.
 To run the output, provide the runtime loaded variables and invoke the pre-built executable
 
 .. code:: bash
 
-   OQC_PASSWORD=<password> ./executable
+   ./executable
 
 To emulate the OQC device locally, without submitting through the OQC QCaaS services, you can pass the ``--emulate`` flag to ``nvq++``.
 This will emit any target specific compiler warnings and diagnostics, before running a noise free emulation.
@@ -579,13 +581,6 @@ This will emit any target specific compiler warnings and diagnostics, before run
 
     nvq++ --emulate --target oqc src.cpp -o executable
 
-
-.. note::
-
-    The oqc target supports a ``--oqc-machine`` option.
-    The default is the 8 qubit Lucy device.
-    You can set this to be either ``toshiko`` or ``lucy`` via this flag.
-
 .. note::
 
     The OQC quantum assembly toolchain (qat) which is used to compile and execute instructions can be found on github as `oqc-community/qat <https://github.com/oqc-community/qat>`__
@@ -593,17 +588,17 @@ This will emit any target specific compiler warnings and diagnostics, before run
 Submission from Python
 `````````````````````````
 
-To set which OQC URL, set the :code:`url` parameter.
-To set which OQC email, set the :code:`email` parameter.
-To set which OQC machine, set the :code:`machine` parameter.
+The environment variables of OQC_URL, OQC_DEVICE, and OQC_AUTH_TOKEN are necessary as with C++. Users also can define those within Python codes as
 
 .. code:: python
 
     import os
     import cudaq
     # ...
-    os.environ['OQC_PASSWORD'] = password
-    cudaq.set_target("oqc", url=url, machine="lucy")
+    os.environ['OQC_URL'] = "https://cloud.oqc.app"
+    os.environ['OQC_DEVICE'] = "qpu:uk:2:d865b5a184"
+    os.environ['OQC_AUTH_TOKEN'] = <your_auth_token>
+    cudaq.set_target("oqc")
 
 You can then execute a kernel against the platform using the OQC Lucy device
 

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -18,7 +18,10 @@ namespace cudaq {
 
 const std::string Lucy = "lucy";
 const std::string Toshiko = "toshiko";
-const std::map<std::string, uint> Machines = {{Lucy, 8}, {Toshiko, 32}};
+//const std::map<std::string, uint> Machines = {{Lucy, 8}, {Toshiko, 32}};
+const std::map<std::string, uint> Machines = {{Lucy, 8}, {Toshiko, 8}}; //Due to placement issues
+const std::map<uint, std::string> machineGeneration = {{2,Lucy}, {3,Toshiko}};
+
 
 /// @brief The OQCServerHelper class extends the ServerHelper class to handle
 /// interactions with the OQC server for submitting and retrieving quantum
@@ -143,6 +146,18 @@ void check_machine_allowed(const std::string &machine) {
 
 } // namespace
 
+std::vector<std::string> split_string(const std::string &s, char delimiter) {
+    std::vector<std::string> tokens;
+    std::stringstream ss(s);
+    std::string token;
+
+    while (std::getline(ss, token, delimiter)) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+
 // Initialize the OQC server helper with a given backend configuration
 void OQCServerHelper::initialize(BackendConfig config) {
 
@@ -150,8 +165,24 @@ void OQCServerHelper::initialize(BackendConfig config) {
 
   // Fetch machine info before checking emulate because we want to be able to
   // emulate specific machines.
-  auto machine = get_from_config(config, "machine", []() { return Lucy; });
-  check_machine_allowed(machine);
+  //auto machine = get_from_config(config, "machine", []() { return Lucy; });
+  //check_machine_allowed(machine);
+  auto qpu_id_str = get_from_config(config, "device", make_env_functor("OQC_DEVICE"));
+  auto device_id_split = split_string(qpu_id_str,':');
+  uint device_generation = std::stoul(device_id_split[2]);
+  std::string machine;
+  try {
+      machine = machineGeneration.at(device_generation);
+      std::stringstream msg;
+      msg << "The architecture of OQC device is: " << machine << std::endl;
+      cudaq::info(msg.str());
+  } catch (const std::out_of_range& e) {
+      machine = "NA";
+      std::stringstream msg;
+      msg << "Generation:"<<machine<<" is not registered.\n Quit." << std::endl;
+      throw std::runtime_error(msg.str());
+  }
+
   config["machine"] = machine;
   const auto emulate_it = config.find("emulate");
   if (emulate_it != config.end() && emulate_it->second == "true") {

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/OQCServerHelp.cpp
@@ -18,10 +18,10 @@ namespace cudaq {
 
 const std::string Lucy = "lucy";
 const std::string Toshiko = "toshiko";
-//const std::map<std::string, uint> Machines = {{Lucy, 8}, {Toshiko, 32}};
-const std::map<std::string, uint> Machines = {{Lucy, 8}, {Toshiko, 8}}; //Due to placement issues
-const std::map<uint, std::string> machineGeneration = {{2,Lucy}, {3,Toshiko}};
-
+// const std::map<std::string, uint> Machines = {{Lucy, 8}, {Toshiko, 32}};
+const std::map<std::string, uint> Machines = {
+    {Lucy, 8}, {Toshiko, 8}}; // Due to placement issues
+const std::map<uint, std::string> machineGeneration = {{2, Lucy}, {3, Toshiko}};
 
 /// @brief The OQCServerHelper class extends the ServerHelper class to handle
 /// interactions with the OQC server for submitting and retrieving quantum
@@ -147,16 +147,15 @@ void check_machine_allowed(const std::string &machine) {
 } // namespace
 
 std::vector<std::string> split_string(const std::string &s, char delimiter) {
-    std::vector<std::string> tokens;
-    std::stringstream ss(s);
-    std::string token;
+  std::vector<std::string> tokens;
+  std::stringstream ss(s);
+  std::string token;
 
-    while (std::getline(ss, token, delimiter)) {
-        tokens.push_back(token);
-    }
-    return tokens;
+  while (std::getline(ss, token, delimiter)) {
+    tokens.push_back(token);
+  }
+  return tokens;
 }
-
 
 // Initialize the OQC server helper with a given backend configuration
 void OQCServerHelper::initialize(BackendConfig config) {
@@ -165,22 +164,24 @@ void OQCServerHelper::initialize(BackendConfig config) {
 
   // Fetch machine info before checking emulate because we want to be able to
   // emulate specific machines.
-  //auto machine = get_from_config(config, "machine", []() { return Lucy; });
-  //check_machine_allowed(machine);
-  auto qpu_id_str = get_from_config(config, "device", make_env_functor("OQC_DEVICE"));
-  auto device_id_split = split_string(qpu_id_str,':');
+  // auto machine = get_from_config(config, "machine", []() { return Lucy; });
+  // check_machine_allowed(machine);
+  auto qpu_id_str =
+      get_from_config(config, "device", make_env_functor("OQC_DEVICE"));
+  auto device_id_split = split_string(qpu_id_str, ':');
   uint device_generation = std::stoul(device_id_split[2]);
   std::string machine;
   try {
-      machine = machineGeneration.at(device_generation);
-      std::stringstream msg;
-      msg << "The architecture of OQC device is: " << machine << std::endl;
-      cudaq::info(msg.str());
-  } catch (const std::out_of_range& e) {
-      machine = "NA";
-      std::stringstream msg;
-      msg << "Generation:"<<machine<<" is not registered.\n Quit." << std::endl;
-      throw std::runtime_error(msg.str());
+    machine = machineGeneration.at(device_generation);
+    std::stringstream msg;
+    msg << "The architecture of OQC device is: " << machine << std::endl;
+    cudaq::info(msg.str());
+  } catch (const std::out_of_range &e) {
+    machine = "NA";
+    std::stringstream msg;
+    msg << "Generation:" << machine << " is not registered.\n Quit."
+        << std::endl;
+    throw std::runtime_error(msg.str());
   }
 
   config["machine"] = machine;

--- a/runtime/cudaq/platform/default/rest/helpers/oqc/toshiko.txt
+++ b/runtime/cudaq/platform/default/rest/helpers/oqc/toshiko.txt
@@ -8,7 +8,7 @@
 
 # The format of the file is as follows:
 # 1. You must specify the number of nodes
-Number of nodes: 35
+Number of nodes: 8
 
 # 2. Specifying the number of edges is optional
 Number of edges: ?
@@ -21,37 +21,16 @@ Number of edges: ?
 # - The nodes and lines do not have to be in order.
 # - Connections are assumed to be bidirectional.
 # - Any duplicates will be automatically removed.
-# Theoretical connectivity for Toshiko. Reality is 32 of 35 will be enabled.
-0 --> {1, 9}
-1 --> {2, 8}
-2 --> {3}
-3 --> {4}
-4 --> {7, 5}
-5 --> {6}
-6 --> {15}
-7 --> {14}
-8 --> {11}
-9 --> {10}
-10 --> {18}
-11 --> {12}
-12 --> {13}
-13 --> {17, 14}
-15 --> {16}
-16 --> {24}
-17 --> {21}
-18 --> {19}
-19 --> {28}
-20 --> {21}
-20 --> {27}
-21 --> {22}
-23 --> {26}
-24 --> {25}
-25 --> {34}
-26 --> {33}
-27 --> {30}
-28 --> {29}
-29 --> {30}
-30 --> {31}
-31 --> {32}
-32 --> {33}
-33 --> {34}
+# As Toshiko uses directional graph (CX is directed), serverside compilation
+# is needed. Here all-to-all connection is defined as it would generate the
+# simplest QIR. In this regard I limit the num of qubits to 8.
+# In the future, once the directional graph is implemented on CUDAQ, 
+# we would back to the actual connectivity. But dont forget; Each Toshiko
+# has its own connectivity. Not identical.
+0 --> {1, 2, 3, 4, 5, 6, 7}
+1 --> {2, 3, 4, 5, 6, 7}
+2 --> {3, 4, 5, 6, 7}
+3 --> {4, 5, 6, 7}
+4 --> {5, 6, 7}
+5 --> {6, 7}
+5 --> {7}


### PR DESCRIPTION
<!--
Thanks for helping us improve CUDA-Q!

⚠️ The pull request title should be concise and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Checklist:
- [] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Description
<!-- Include relevant issues here, describe what changed and why -->
To use Toshiko QPU of OQC, we need to base on directional graph as CX gate has direction. At this moment, CUDA-Q does not handle this. In this regard, we emit a QIR that assumes 8 qubits full connectivity QPU which may generate the simplest code, and then optimize on the serverside.